### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Publish Package to npm
+permissions:
+  contents: read
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/owpz/prisma-ksuid/security/code-scanning/1](https://github.com/owpz/prisma-ksuid/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Since the workflow involves reading the repository contents and publishing to npm, we will set `contents: read` and no other permissions. This ensures that the GITHUB_TOKEN has minimal access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
