### PR TITLE
fix: limit Jest maxWorkers to 1 to prevent SQLite test failures

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,4 +11,5 @@ module.exports = {
   collectCoverageFrom: ["src/**/*.ts", "!src/**/*.d.ts"],
   testTimeout: 30000, // Increase timeout for E2E tests
   setupFilesAfterEnv: [],
+  maxWorkers: 1, // Prevent parallel DB resets that break SQLite foreign keys
 };


### PR DESCRIPTION
## Summary
- Fixes test failures on Node 20 caused by parallel database resets
- Limits Jest maxWorkers to 1 to avoid SQLite foreign key constraint issues during tests

## Changes

### Test Configuration
- Updated `jest.config.ts` to add `maxWorkers: 1` setting
  - Prevents parallel test execution that breaks SQLite foreign keys
  - Ensures stable and reliable test runs on Node 20 environment

## Test plan
- [x] Run full test suite to confirm no SQLite foreign key errors
- [x] Verify tests pass consistently on Node 20
- [x] Confirm no regressions in test coverage or timeout behavior

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/31db08c9-ce6f-43da-8372-baa0d6f64ebe