### PR TITLE
Add OpenSSF Scorecard GitHub Action with non-failing workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,12 +29,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
@@ -46,7 +46,7 @@ jobs:
 
       # Upload the results as artifacts (optional). Useful for debugging
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@84480863f228bb9747b473957fcc9e309aa96097 # v4.4.2
         with:
           name: SARIF file
           path: results.sarif
@@ -55,7 +55,7 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # This will show security issues in the Security tab
       - name: "Upload SARIF results to code scanning"
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@6db8d6351fd0be61f9ed8ebd12ccd35dcec51fea # v3.26.11
         with:
           sarif_file: results.sarif
         # Continue even if upload fails - don't break the workflow

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,62 @@
+name: OpenSSF Scorecard
+on:
+  # Run on all pushes to the default branch, and on all pull requests.
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  # Also run weekly to pick up any security updates
+  schedule:
+    - cron: '0 2 * * 0'
+  # Allow manual runs
+  workflow_dispatch:
+
+# Declare default permissions as read only
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload results to code-scanning dashboard
+      security-events: write
+      # Needed to publish results
+      id-token: write
+      # Uncomment the permissions below if installing the Scorecard Action from GitHub Marketplace
+      # actions: read
+      # contents: read
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to OpenSSF REST API
+          publish_results: true
+          # Don't fail the action on low scores - we just want to monitor
+          # Setting repo_token but the action will continue regardless of score
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Upload the results as artifacts (optional). Useful for debugging
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # This will show security issues in the Security tab
+      - name: "Upload SARIF results to code scanning"
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+        # Continue even if upload fails - don't break the workflow
+        continue-on-error: true


### PR DESCRIPTION
## Summary
- Introduces a new GitHub Actions workflow to run OpenSSF Scorecard analysis
- Automatically runs on pushes and pull requests to the main branch, weekly schedule, and manual triggers
- Publishes security score results without failing the workflow on low scores
- Uploads SARIF results as artifacts and to GitHub's code scanning dashboard

## Changes

### GitHub Actions Workflow
- Added `.github/workflows/scorecard.yml` file
- Configured to run on:
  - Pushes to `main` branch
  - Pull requests targeting `main`
  - Weekly schedule (every Sunday at 2 AM UTC)
  - Manual workflow dispatch
- Permissions set to read-only by default with specific write permissions for security events and ID token
- Steps include:
  - Checkout code without persisting credentials
  - Run OpenSSF Scorecard analysis using `ossf/scorecard-action@v2.4.0`
  - Publish results to OpenSSF REST API and GitHub code scanning dashboard
  - Upload SARIF results as artifacts for debugging
  - Continue workflow even if SARIF upload fails to avoid breaking the workflow

## Test plan
- [ ] Verify workflow triggers on push, pull request, schedule, and manual dispatch
- [ ] Confirm Scorecard analysis runs and results are published
- [ ] Check SARIF artifact upload and code scanning dashboard integration
- [ ] Ensure workflow does not fail on low security scores or upload errors

This addition enhances security monitoring by integrating OpenSSF Scorecard checks into the CI pipeline without blocking development progress.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/75f80112-ac8b-4326-95d5-fe6f2f719d69