### PR TITLE
Fix GitHub workflow permissions and pin action versions

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@595b5aeba73380359d98a5e087f648dbb0edce1b # v4
         with:
           # Fail on vulnerabilities of moderate severity or higher
           fail-on-severity: moderate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
       # Verify version matches between tag and package.json
       - name: Verify version
         run: |
@@ -39,7 +39,7 @@ jobs:
       # Setup Node.js environment
       # Using SHA pin instead of version tag for security (prevents unexpected changes if the tag is moved)
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 jobs:
   test:
@@ -20,11 +19,11 @@ jobs:
 
     steps:
       # Checkout repository code
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
       # Setup Node.js environment
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
@@ -56,6 +55,6 @@ jobs:
 
       # Upload test coverage reports
       - name: Upload coverage reports
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
         with:
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- Updated GitHub workflow permissions to remove unnecessary `actions: write` permission in test workflow
- Pinned GitHub Actions to specific commit SHAs for improved security and stability

## Changes

### Workflow Updates
- **dependency-review.yml**: Pinned `actions/checkout` and `actions/dependency-review-action` to specific commit SHAs
- **publish.yml**: Pinned `actions/checkout` and `actions/setup-node` to specific commit SHAs
- **test.yml**:
  - Removed `actions: write` permission to follow least privilege principle
  - Pinned `actions/checkout`, `actions/setup-node`, and `codecov/codecov-action` to specific commit SHAs

## Test plan
- Verified workflows run successfully with updated permissions and pinned action versions
- Confirmed no regressions in dependency review, publishing, and testing workflows

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e7bed560-b6e1-490b-9aed-3418e17447c6